### PR TITLE
portlint foo and install

### DIFF
--- a/net-mgmt/lldpd/Makefile
+++ b/net-mgmt/lldpd/Makefile
@@ -11,14 +11,16 @@ COMMENT=	LLDP (802.1ab)/CDP/EDP/SONMP/FDP daemon and SNMP subagent
 
 LICENSE=	ISCL
 
-RUN_DEPENDS=	libevent2>=2.0.5:${PORTSDIR}/devel/libevent2
+LIB_DEPENDS=	libevent.so:${PORTSDIR}/devel/libevent2
+
+OPTIONS_SUB=	yes
 
 USE_RC_SUBR=	lldpd
 
 USES=		libtool
 USE_LDCONFIG=	yes
 GNU_CONFIGURE=	yes
-#CONFIGURE_ENV+=	PKG_CONFIG_LIBDIR=/usr/local/var/libdata/pkgconfig
+#CONFIGURE_ENV+=	PKG_CONFIG_LIBDIR=${PREFIX}/libdata/pkgconfig
 CONFIGURE_ARGS=	--enable-privsep \
 		--with-privsep-chroot=/var/run/lldpd
 
@@ -28,7 +30,7 @@ GROUPS=	_lldpd
 OPTIONS_GROUP=		DOCS
 OPTIONS_GROUP_DOCS=	CHI CHM DOT HTML PDF PS RTF XML
 
-OPTIONS_DEFINE=		LLDP-MED DOT1 DOT3 PROPRIETARY DTRACE MAN JSON SNMP XML
+OPTIONS_DEFINE=		LLDP-MED DOT1 DOT3 PROPRIETARY DTRACE MAN JSON SNMP DOCS
 OPTIONS_DEFAULT=	LLDP-MED DOT1 DOT3 MAN
 
 # Descriptions
@@ -88,6 +90,8 @@ XML_BUILD_DEPENDS=	doxygen:${PORTSDIR}/devel/doxygen
 
 post-stage:
 	@${MKDIR} ${STAGEDIR}/var/run/lldpd
+	${CP} ${STAGEDIR}${PREFIX}/lib/pkgconfig/* \
+	    ${STAGEDIR}${PREFIX}/libdata/pkgconfig/
 
 .include <bsd.port.options.mk>
 

--- a/net-mgmt/lldpd/pkg-plist
+++ b/net-mgmt/lldpd/pkg-plist
@@ -1,22 +1,21 @@
 etc/bash_completion.d/lldpcli.bash-completion
 %%ETCDIR%%.d/README.conf
-etc/rc.d/lldpd
 include/lldp-const.h
 include/lldpctl.h
 lib/liblldpctl.a
 lib/liblldpctl.so
 lib/liblldpctl.so.4
 lib/liblldpctl.so.4.4.0
-lib/pkgconfig/lldpctl.pc
+libdata/pkgconfig/lldpctl.pc
 man/man8/lldpcli.8.gz
 man/man8/lldpctl.8.gz
 man/man8/lldpd.8.gz
 sbin/lldpcli
 sbin/lldpctl
 sbin/lldpd
-%%PORTDOCS%%%%DOCSDIR%%/CONTRIBUTE.md
-%%PORTDOCS%%%%DOCSDIR%%/ChangeLog
-%%PORTDOCS%%%%DOCSDIR%%/NEWS
-%%PORTDOCS%%%%DOCSDIR%%/README.md
+%%DOCS%%%%PORTDOCS%%%%DOCSDIR%%/CONTRIBUTE.md
+%%DOCS%%%%PORTDOCS%%%%DOCSDIR%%/ChangeLog
+%%DOCS%%%%PORTDOCS%%%%DOCSDIR%%/NEWS
+%%DOCS%%%%PORTDOCS%%%%DOCSDIR%%/README.md
 share/zsh/vendor-completions/_lldpcli
 @dir /var/run/lldpd


### PR DESCRIPTION
Einen Schritt weiter... PKG_CONFIG_LIBDIR funktioniert nicht--das sieht aber nach dem besseren Fix aus für libdata/pkgconfig als der der jetzt drin ist. Doxygen sprengt alle Ketten beim Bauen. Texlive ist viel zu viel für einen net-mgmt Port. Ansonsten schön weitermachen. :+1: 
